### PR TITLE
fix: make HasPermission ordering-independent via permission set

### DIFF
--- a/internal/models/api_key.go
+++ b/internal/models/api_key.go
@@ -78,21 +78,17 @@ func NewKeyID() string {
 }
 
 // HasPermission returns true when the key is enabled and possesses the required permission.
+// Permission hierarchy: admin (and "*") grant everything; write grants read and write.
+// Result is independent of the order of elements in Permissions.
 func (ak *APIKey) HasPermission(required string) bool {
 	if ak == nil || !ak.Enabled {
 		return false
 	}
+	perms := make(map[string]bool, len(ak.Permissions))
 	for _, p := range ak.Permissions {
-		switch p {
-		case "*", "admin":
-			return true
-		case "write":
-			if required == "read" || required == "write" {
-				return true
-			}
-		case required:
-			return true
-		}
+		perms[p] = true
 	}
-	return false
+	return perms["*"] || perms["admin"] ||
+		(perms["write"] && (required == "read" || required == "write")) ||
+		perms[required]
 }

--- a/internal/models/api_key_test.go
+++ b/internal/models/api_key_test.go
@@ -43,6 +43,12 @@ func TestAPIKeyHasPermission(t *testing.T) {
 		{"read denied write", []string{"read"}, true, "write", false},
 		{"wildcard grants all", []string{"*"}, true, "admin", true},
 		{"disabled key denied", []string{"admin"}, false, "read", false},
+		// Multi-permission keys: result must not depend on slice order.
+		{"write then admin grants admin", []string{"write", "admin"}, true, "admin", true},
+		{"admin then write grants read", []string{"admin", "write"}, true, "read", true},
+		{"write then admin grants read", []string{"write", "admin"}, true, "read", true},
+		{"read then write grants write", []string{"read", "write"}, true, "write", true},
+		{"write then read grants read", []string{"write", "read"}, true, "read", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #65.

Investigation found no runtime ordering bug in the current code — `case "write"` never returns `false`, so the loop always continues to subsequent permissions. However, the switch-on-p implementation was fragile: a reader could reasonably believe the `"write"` case caused an early `false` return when the condition was unmet, and a future refactor could easily introduce exactly that bug.

**Root cause:** The code was not obviously ordering-independent, and multi-permission keys were entirely untested.

**Fix:** Replace the switch loop with a set-based implementation that builds a `map[string]bool` of all permissions first, then evaluates the hierarchy in a single expression. The result is provably independent of slice order by construction.

**Tests:** Add 5 multi-permission test cases covering the orderings that were previously untested (`["write", "admin"]` checking admin, `["admin", "write"]` checking read, etc.). These pass on both the old and new implementation, documenting expected behaviour and guarding against future regressions.

## Test plan

- [ ] `make check` passes
- [ ] `TestAPIKeyHasPermission` covers multi-permission keys in both orderings