### PR TITLE
fix: replace bare string context key with typed contextKey

### DIFF
--- a/internal/api/handlers_keys.go
+++ b/internal/api/handlers_keys.go
@@ -208,7 +208,7 @@ func (h *Handlers) DeleteAPIKey(w http.ResponseWriter, r *http.Request) {
 
 // actorKeyID extracts the ID of the authenticated key making this request.
 func actorKeyID(r *http.Request) string {
-	if k, ok := r.Context().Value("api_key").(*models.APIKey); ok {
+	if k, ok := r.Context().Value(apiKeyContextKey).(*models.APIKey); ok {
 		return k.ID
 	}
 	return "unknown"

--- a/internal/api/handlers_keys_test.go
+++ b/internal/api/handlers_keys_test.go
@@ -42,7 +42,7 @@ func adminCtxRequest(method, path string, body []byte, store storage.Storage, ra
 	}
 	hash := models.HashAPIKey(rawKey)
 	ak, _ := store.GetAPIKeyByHash(context.Background(), hash)
-	ctx := context.WithValue(req.Context(), "api_key", ak)
+	ctx := context.WithValue(req.Context(), apiKeyContextKey, ak)
 	return req.WithContext(ctx)
 }
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -20,10 +20,17 @@ const (
 	PermissionAdmin Permission = "admin"
 )
 
+// contextKey is an unexported type for context keys in this package.
+// Using a named type prevents collisions with context keys from other packages.
+type contextKey struct{}
+
+// apiKeyContextKey is the context key used to store and retrieve the authenticated API key.
+var apiKeyContextKey = contextKey{}
+
 // GetAPIKey extracts the authenticated API key from request context.
 // Returns nil if no key is present (unauthenticated request).
 func GetAPIKey(r *http.Request) *models.APIKey {
-	if apiKey, ok := r.Context().Value("api_key").(*models.APIKey); ok {
+	if apiKey, ok := r.Context().Value(apiKeyContextKey).(*models.APIKey); ok {
 		return apiKey
 	}
 	return nil
@@ -82,7 +89,7 @@ func OptionalAuth(store storage.Storage) mux.MiddlewareFunc {
 			}
 
 			// Add API key info to context for handlers to use
-			ctx := context.WithValue(r.Context(), "api_key", validKey)
+			ctx := context.WithValue(r.Context(), apiKeyContextKey, validKey)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -87,7 +87,7 @@ func TestOptionalAuthWithStorage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var ctxKey *models.APIKey
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				ctxKey, _ = r.Context().Value("api_key").(*models.APIKey)
+				ctxKey, _ = r.Context().Value(apiKeyContextKey).(*models.APIKey)
 				w.WriteHeader(http.StatusOK)
 			})
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -245,7 +245,7 @@ func authMiddleware(store storage.Storage) mux.MiddlewareFunc {
 				json.NewEncoder(w).Encode(errorResp)
 				return
 			}
-			ctx := context.WithValue(r.Context(), "api_key", validKey)
+			ctx := context.WithValue(r.Context(), apiKeyContextKey, validKey)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -185,7 +185,7 @@ func TestAuthMiddleware(t *testing.T) {
 			// Create test handler
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// Check if API key is in context
-				apiKey := r.Context().Value("api_key")
+				apiKey := r.Context().Value(apiKeyContextKey)
 				if tt.expectAPIKeyInCtx {
 					assert.NotNil(t, apiKey, "Expected API key in context")
 					if actualKey, ok := apiKey.(*models.APIKey); ok {
@@ -304,7 +304,7 @@ func TestRequirePermissionMiddleware(t *testing.T) {
 			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if tt.apiKey != nil {
 					// Add API key to context (simulating auth middleware)
-					ctx := context.WithValue(r.Context(), "api_key", tt.apiKey)
+					ctx := context.WithValue(r.Context(), apiKeyContextKey, tt.apiKey)
 					r = r.WithContext(ctx)
 				}
 				middleware(handler).ServeHTTP(w, r)
@@ -884,7 +884,7 @@ func TestOptionalAuthMiddleware(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create test handler
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				apiKey := r.Context().Value("api_key")
+				apiKey := r.Context().Value(apiKeyContextKey)
 				if tt.expectAPIKeyInCtx {
 					assert.NotNil(t, apiKey, "Expected API key in context")
 				} else {


### PR DESCRIPTION
## Summary

Fixes #77.

Using a plain string `"api_key"` as a context key violates Go documentation guidance: any package using the same string can silently read or overwrite the value. As the codebase grows and middleware is added, this is a correctness risk with no compile-time protection.

Define an unexported `contextKey struct{}` type and a package-level `apiKeyContextKey` variable in `internal/api/middleware.go`. The unexported type guarantees no external package can construct an identical key — collisions are impossible by construction.

**Changed files:**
- `middleware.go` — type definition + key variable; update `GetAPIKey` and `OptionalAuth`
- `routes.go` — update `authMiddleware`
- `handlers_keys.go` — update `actorKeyID`
- `security_test.go`, `middleware_test.go`, `handlers_keys_test.go` — update all test usages

## Test plan

- [ ] `make check` passes
- [ ] All 9 usages of the bare `"api_key"` string as a context key replaced