### PR TITLE
ci: skip GHCR push for fork PRs, build only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,24 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}
+          LATEST_TAG: latest-dev
+        run: |
+          chmod +x ./scripts/docker-build.sh
+          make docker-build
+
       - name: Build and push
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}
           LATEST_TAG: latest-dev


### PR DESCRIPTION
## Summary

- Fork PRs lack write access to `packages`, causing the "Build and push to GHCR" job to fail with a credentials error
- Detect fork PRs using `github.event.pull_request.head.repo.full_name != github.repository`
- Skip the GHCR login step for fork PRs
- Run `make docker-build` (build only, no push) for fork PRs to verify the image still builds
- Non-fork PRs and pushes to `main` continue to run `make docker-push` as before

## Test plan

- [x] Verify this PR's own CI passes (non-fork, so should build and push as normal)
- [ ] Verify PR #119 (fork) now shows the publish job succeeding with build-only